### PR TITLE
Fix external deps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
             server: {
                 options: {
                     port: 9001,
-                    base: './'
+                    base: './dist/'
                 }
             }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,30 @@ module.exports = function (grunt) {
                         cwd: 'src/js/',
                         src: 'app.js',
                         dest: 'dist/js/'
+                    },
+                    {
+                        expand: true,
+                        cwd: 'node_modules/jquery/dist/',
+                        src: 'jquery.min.js',
+                        dest: 'dist/js/vendor/'
+                    },
+                    {
+                        expand: true,
+                        cwd: 'node_modules/html5shiv/dist/',
+                        src: 'html5shiv.min.js',
+                        dest: 'dist/js/vendor/'
+                    },
+                    {
+                        expand: true,
+                        cwd: 'node_modules/respond.js/dest/',
+                        src: 'respond.min.js',
+                        dest: 'dist/js/vendor/'
+                    },
+                    {
+                        expand: true,
+                        cwd: 'node_modules/bootstrap-sass/assets/javascripts/',
+                        src: 'bootstrap.min.js',
+                        dest: 'dist/js/vendor/'
                     }
                 ]
             }

--- a/src/doc/layouts/default.hbs
+++ b/src/doc/layouts/default.hbs
@@ -11,11 +11,11 @@
     
     <link rel="stylesheet" href="css/app.css?{{ version }}" />
 
-    <script src="../node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="js/vendor/jquery.min.js"></script>
 
     <!--[if lt IE 9]>
-        <script src="../node_modules/html5shiv/html5shiv.min.js"></script>
-        <script src="../node_modules/respond.js/dest/respond.min.js"></script>
+        <script src="js/vendor/html5shiv.min.js"></script>
+        <script src="js/vendor/respond.min.js"></script>
     <![endif]-->
 </head>
 

--- a/src/doc/partials/scripts.hbs
+++ b/src/doc/partials/scripts.hbs
@@ -1,2 +1,2 @@
-﻿<script src="../node_modules/bootstrap-sass/assets/javascripts/bootstrap.min.js"></script>
+﻿<script src="js/vendor/bootstrap.min.js"></script>
 <script src="js/app.js"></script>


### PR DESCRIPTION
my last fix for supporting no externals was incomplete.  It was also masked when built locally. This caused all scripts to not load only when deployed (i.e., to azure, etc).

I made two fixes here.
1. update the local server to correctly reflect the same root as the deployment environment
2. update the references to the static resources, and ensuring they are in scope with 'dist' as the proper root.