### PR TITLE
moved required bower dependencies from devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": "",
   "description": "Microsoft Bootstrap Theme for Metro 2.0 (Basel)",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "bootstrap-sass": "~3.3.4",
     "jquery": "~2.1.4"
   }


### PR DESCRIPTION
without this, when another project includes bswjs via bower, it won't build properly as it won't have necessarily installed the required dependencies.