### PR TITLE
Fix input readonly state on focus

### DIFF
--- a/src/scss/override/_forms.scss
+++ b/src/scss/override/_forms.scss
@@ -242,6 +242,11 @@ textarea.form-control {
         border-color: $color-neutral-low;
         background-color: $color-neutral-low-alt;
     }
+        
+    &[readonly]:focus {
+        background: $color-dim-mid;
+        border-color: $color-vivid-low;   
+    }
 }
 
 input.form-control::-ms-clear,


### PR DESCRIPTION
The readonly state does not have specific styling for :focus for text input #167