### PR TITLE
Fix progress bar

### DIFF
--- a/src/scss/win/_progress-bar.scss
+++ b/src/scss/win/_progress-bar.scss
@@ -1,7 +1,7 @@
 .progress-bar {
   position: relative;
   width: 180px;
-  float: inherit;
+  float: left;
   display: inline-block;
 
   .progress-circle {


### PR DESCRIPTION
Float should be declared when progress-bar is an inline-block.
Related issue: Determinate progress bar does not show progress any more #169